### PR TITLE
Update ecto

### DIFF
--- a/lib/mix/tasks/exseed.seed.ex
+++ b/lib/mix/tasks/exseed.seed.ex
@@ -21,7 +21,7 @@ defmodule Mix.Tasks.Exseed.Seed do
   def run(args) do
     repo = parse_repo(args)
 
-    ensure_repo(repo)
+    ensure_repo(repo, [])
 
     Mix.Task.run "app.start", args
 

--- a/mix.exs
+++ b/mix.exs
@@ -26,7 +26,7 @@ defmodule Exseed.Mixfile do
 
   defp deps do
     [
-     { :ecto, ">= 0.10.0" },
+     { :ecto, ">= 1.0.0" },
     ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,3 +1,3 @@
 %{"decimal": {:hex, :decimal, "1.1.0"},
-  "ecto": {:hex, :ecto, "0.11.1"},
+  "ecto": {:hex, :ecto, "1.0.6"},
   "poolboy": {:hex, :poolboy, "1.5.1"}}


### PR DESCRIPTION
Updates ecto to >= 1.0.0

This was needed because exseed breaks with newer versions of ecto where `ensure_repo/1` has been replaced by `ensure_repo/2` (in [this commit](https://github.com/elixir-lang/ecto/commit/5dda1b39b167efd759a68aaa9d23c60819dac113)).
