### PR TITLE
Fix multiple repos support

### DIFF
--- a/lib/mix/tasks/exseed.seed.ex
+++ b/lib/mix/tasks/exseed.seed.ex
@@ -18,26 +18,28 @@ defmodule Mix.Tasks.Exseed.Seed do
   import Mix.Ecto
 
   def run(args) do
-    repo = parse_repo(args)
+    repos = parse_repo(args)
 
-    ensure_repo(repo, [])
+    Enum.each repos, fn repo ->
+      ensure_repo(repo, [])
 
-    Mix.Task.run "app.start", args
+      Mix.Task.run "app.start", args
 
-    {opts, _, _} = OptionParser.parse args, switches: [quiet: :boolean, path: :string]
+      {opts, _, _} = OptionParser.parse args, switches: [quiet: :boolean, path: :string]
 
-    seed_path = opts[:path] || "priv/repo/seeds/"
+      seed_path = opts[:path] || "priv/repo/seeds/"
 
-    unless File.exists?(seed_path) do
-      raise File.Error, reason: :enoent, action: "find", path: seed_path
-    end
+      unless File.exists?(seed_path) do
+        raise File.Error, reason: :enoent, action: "find", path: seed_path
+      end
 
-    {:ok, seed_files} = File.ls(seed_path)
+      {:ok, seed_files} = File.ls(seed_path)
 
-    seed_files |> Enum.each(&(Code.load_file(Path.join(seed_path, &1))))
+      seed_files |> Enum.each(&(Code.load_file(Path.join(seed_path, &1))))
 
-    unless opts[:quiet] do
-      Mix.shell.info "The database for #{inspect repo} has been seeded."
+      unless opts[:quiet] do
+        Mix.shell.info "The database for #{inspect repo} has been seeded."
+      end
     end
   end
 end


### PR DESCRIPTION
Current version does not work with Ecto 2.

```
~/p/blog(master ✗) mix exseed.seed
==> exseed
Compiling 1 file (.ex)
Args
** (FunctionClauseError) no function clause matching in Code.ensure_compiled/1
    (elixir) lib/code.ex:542: Code.ensure_compiled([ExBlog.repo])
    lib/mix/ecto.ex:66: Mix.Ecto.ensure_repo/2
    lib/mix/tasks/exseed.seed.ex:24: Mix.Tasks.Exseed.Seed.run/1
    (mix) lib/mix/task.ex:296: Mix.Task.run_task/3
    (mix) lib/mix/cli.ex:58: Mix.CLI.run_task/2
    (elixir) lib/code.ex:363: Code.require_file/2

```

Looks like at current Ecto version(2.0.5) `parse_repo/1` returns a list of repos.

This PR makes mix task behaviour similar to standard mix tasks.