### PR TITLE
Fix FunctionClauseError on Code.ensure_compiled on Ecto 1.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,18 @@
+# https://github.com/CircleCI-Public/circleci-demo-elixir-phoenix
+version: 2.0
+jobs:
+  build:
+    working_directory: ~/exseed
+    docker:
+      - image: elixir:1.5.1
+        environment:
+          - MIX_ENV=test
+      - image: postgres:9.6.3
+        environment:
+          - POSTGRES_USER=postgres
+    steps:
+      - checkout
+      - run: echo "Yes" | mix local.hex
+      - run: echo "Yes" | mix local.rebar
+      - run: mix deps.get
+      - run: mix test

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ An Elixir library that provides a simple DSL for seeding databases through Ecto.
 
 Inspired largely by [seed-fu](https://github.com/mbleigh/seed-fu).
 
+[![CircleCI](https://circleci.com/gh/seaneshbaugh/exseed/tree/master.svg?style=svg)](https://circleci.com/gh/seaneshbaugh/exseed/tree/master)
+
 ## Installation
 
 In your project's `mix.exs` add the following:

--- a/lib/mix/tasks/exseed.seed.ex
+++ b/lib/mix/tasks/exseed.seed.ex
@@ -18,26 +18,28 @@ defmodule Mix.Tasks.Exseed.Seed do
   import Mix.Ecto
 
   def run(args) do
-    repo = parse_repo(args)
+    repos = parse_repo(args)
 
-    ensure_repo(repo, [])
+    Enum.each repos, fn repo ->
+      ensure_repo(repo, [])
 
-    Mix.Task.run "app.start", args
+      Mix.Task.run "app.start", args
 
-    {opts, _, _} = OptionParser.parse args, switches: [quiet: :boolean, path: :string]
+      {opts, _, _} = OptionParser.parse args, switches: [quiet: :boolean, path: :string]
 
-    seed_path = opts[:path] || "priv/repo/seeds/"
+      seed_path = opts[:path] || "priv/repo/seeds/"
 
-    unless File.exists?(seed_path) do
-      raise File.Error, reason: :enoent, action: "find", path: seed_path
-    end
+      unless File.exists?(seed_path) do
+        raise File.Error, reason: :enoent, action: "find", path: seed_path
+      end
 
-    {:ok, seed_files} = File.ls(seed_path)
+      {:ok, seed_files} = File.ls(seed_path)
 
-    seed_files |> Enum.each(&(Code.load_file(Path.join(seed_path, &1))))
+      seed_files |> Enum.each(&(Code.load_file(Path.join(seed_path, &1))))
 
-    unless opts[:quiet] do
-      Mix.shell.info "The database for #{inspect repo} has been seeded."
+      unless opts[:quiet] do
+        Mix.shell.info "The database for #{inspect repo} has been seeded."
+      end
     end
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -25,7 +25,7 @@ defmodule Exseed.Mixfile do
   defp deps do
     [
       { :earmark, "~> 0.2", only: :dev },
-      { :ecto, ">= 1.0.0" },
+      { :ecto, ">= 1.1.0" },
       { :ex_doc, "~> 0.11", only: :dev }
     ]
   end

--- a/test/mix/tasks/exseed.seed_test.exs
+++ b/test/mix/tasks/exseed.seed_test.exs
@@ -12,6 +12,6 @@ defmodule Mix.Tasks.Exseed.SeedTest do
   test "runs the seed task" do
     Seed.run ["-r", to_string(TestRepo), "--path", "test/support/seeds"]
 
-    assert_received {:mix_shell, :info, ["The database for [Exseed.TestRepo] has been seeded."]}
+    assert_received {:mix_shell, :info, ["The database for Exseed.TestRepo has been seeded."]}
   end
 end


### PR DESCRIPTION
Hello,

I found an following error.

```
** (FunctionClauseError) no function clause matching in Code.ensure_compiled/1    
    
    The following arguments were given to Code.ensure_compiled/1:
    
        # 1
        [MyApp.Repo]
    
    (elixir) lib/code.ex:575: Code.ensure_compiled/1
    lib/mix/ecto.ex:64: Mix.Ecto.ensure_repo/2
    lib/mix/tasks/exseed.seed.ex:23: Mix.Tasks.Exseed.Seed.run/1
    (mix) lib/mix/task.ex:301: Mix.Task.run_task/3
    (mix) lib/mix/cli.ex:75: Mix.CLI.run_task/2
    (elixir) lib/code.ex:376: Code.require_file/2
```

Environments:
- ecto 2.1.5
- exseed 0.0.4

I debugged this error and found a cause.
In Ecto 1.0.0, `Ecto.parse_repo` returns simply `Repo`.
Ref. https://github.com/elixir-ecto/ecto/blob/v1.0/test/mix/ecto_test.exs#L5

But after Ecto 1.1.0, `Ecto.parse_repo` returns `[Repo]`.
Ref. https://github.com/elixir-ecto/ecto/blob/v1.1/test/mix/ecto_test.exs#L5

I fixed this error by using iterator.
Could you merge this?

Thanks,
